### PR TITLE
terran: fix no comsat and turrets

### DIFF
--- a/src/terran/managers/town_manager.pyai
+++ b/src/terran/managers/town_manager.pyai
@@ -81,6 +81,19 @@ multirun_loop:
                 build_start(6, Missile Turret)
         stop()
 
+    ## lazy hack to enable comsat and turrets build vs protoss (human) ##
+    if enemyowns(Citadel of Adun):
+        player_need(1, Engineering Bay)
+        build_start(1, missile turret, 50)
+        build_start(2, missile turret, 50)
+        wait(300)
+        player_need(1, Academy)
+        build_start(1, Comsat Station, 50)
+        wait_until(18)
+        build_start(3, Missile Turret)
+        build_start(4, Missile Turret)
+        stop()
+
 loop:
     wait(300)
     if owned(machine shop):


### PR DESCRIPTION
terran: fix no comsat and turrets against prottoss arbiters due to very delayed stargate build