### PR TITLE
protoss: make sure observers are always build against terran

### DIFF
--- a/src/protoss/managers/tech_manager.pyai
+++ b/src/protoss/managers/tech_manager.pyai
@@ -7,6 +7,10 @@ if enemyowns(Nexus):
     build_finish(1, Robotics Facility)
     build_start(1, Robotics Support Bay)
 
+if enemyowns(Command Center):
+    build_finish(1, Observatory)
+    train(2, Observer)
+
 build_start(3, Gateway)
 build_finish(4, Gateway)
 


### PR DESCRIPTION
protoss: make sure observers are always build against terran even if no cloacked units are present because of terran mines